### PR TITLE
Fix incorrect eval.model_dir in train.json

### DIFF
--- a/conf/train.json
+++ b/conf/train.json
@@ -109,7 +109,7 @@
     "batch_size": 1024,
     "is_flat": true,
     "top_k": 100,
-    "model_dir": "checkpoint_dir_rcv1/TextCNN"
+    "model_dir": "checkpoint_dir_rcv1/TextCNN_best"
   },
   "TextVDCNN": {
     "vdcnn_depth": 9,


### PR DESCRIPTION
This PR fixes incorrect eval.model_dir.

No such file or directory: 'checkpoint_dir_rcv1/TextCNN'
https://colab.research.google.com/drive/14bJpYZ01tIwmu4gxOnP1hBBeZVa0hwFA

This PR is working correctly.
https://colab.research.google.com/drive/1rsRVu7umyo973HdLyUpQZPIflm1uOMoO